### PR TITLE
Python 3.6 string support

### DIFF
--- a/scaffold/projectfiles.py
+++ b/scaffold/projectfiles.py
@@ -24,7 +24,7 @@ def write_setup(project_name, root_dir):
 def write_tests(project_name, root_dir):
     """Writes tests/PROJECT_NAME_tests.py file to disk"""
     #Get the path for setup.py
-    filename = "{project_name}_tests.py".format(project_name=project_name)
+    filename = f"{project_name}_tests.py"
     test_path = get_file_path(root_dir, "tests", filename) 
     test_content = get_test_text(project_name)
     with open(test_path, 'w') as test_file:
@@ -51,11 +51,7 @@ def write_inits(project_name, root_dir):
     print_file(init_paths['project'])
     
 def print_file(path, prefix=' ++++++'):
-    print(
-    "create: {prefix} {path_}".format(
-        prefix=prefix,
-        path_=os.path.abspath(path))
-    )
+    print(f"create: {prefix} {path.abspath(path)}")
 
 def get_file_path(root_dir, sub_dir, filename):
     if sub_dir == None: #In case we're writing directly to the root directory
@@ -68,7 +64,11 @@ def get_file_path(root_dir, sub_dir, filename):
 
 def get_setup_text(project_name):
     #This is quite ghetto, and can probably be improved
-    setup_text = """
+    project = project_name, 
+    author = get_user_name_from_git() or "My Name"
+    author_email = get_user_email_from_git() or "My email."
+    
+    setup_text = f"""
         try:
             from setuptools import setup
         except ImportError:
@@ -76,7 +76,7 @@ def get_setup_text(project_name):
 
         config = {{
             'description': 'My Project',
-            'author': '{author}',
+            'author': '{author}
             'url': 'URL to get it at.',
             'download_url': 'Where to download it.',
             'author_email': '{author_email}',
@@ -89,18 +89,15 @@ def get_setup_text(project_name):
 
         setup(**config)
 
-    """.format(
-            project = project_name, 
-            author = get_user_name_from_git() or "My Name", 
-            author_email = get_user_email_from_git() or "My email.")
+    """
 
     return dedent(setup_text)
 
 def get_test_text(project_name):
     #Again, quite ghetto and can probably be improved, but it works
-    test_text = """
+    test_text = f"""
         from nose.tools import *
-        import {PROJECT}
+        import {project_name}
 
         def setup():
             print("SETUP!")
@@ -110,7 +107,7 @@ def get_test_text(project_name):
 
         def test_basic():
             print("I RAN!")
-    """.format(PROJECT=project_name)
+    """
     
     return dedent(test_text)
 

--- a/scaffold/projectfolders.py
+++ b/scaffold/projectfolders.py
@@ -8,12 +8,12 @@ def create_folders(project_name, current_directory):
 
     if os.path.exists(root_dir) and os.listdir(root_dir):
         #If the path already exists and it is not empty, raise an error
-        err_msg = '''
-            {directory} already exists and it is not empty.
+        err_msg = f'''
+            {root_dir} already exists and it is not empty.
 
             Please try a different project name or root directory.
             
-            '''.format(directory=root_dir)
+            '''
         raise IOError(000, dedent(err_msg))
     else:
         make_folder(root_dir) #Create the root directory
@@ -30,13 +30,10 @@ def make_folder(path, prefix=''):
     os.mkdir(path)
 
     if os.path.exists(path) is False: #If we were unable to make the directory for some reason...
-        err_msg = 'Unable to create root directory {path_}. Unknown error!'.format(path_=path)
+        err_msg = f'Unable to create root directory {path}. Unknown error!'
         raise IOError(000, err_msg, '')
 
-    print("create: {prefix} {path_}".format(
-        prefix=prefix,
-        path_=os.path.abspath(path)
-    ))
+    print(f"create: {prefix} {os.path.abspath(path)}")
 
 def create_path(current_directory, new_folder_name):
     """Gets the absolute path of the new folder we're going to create"""

--- a/tests/scaffold_tests.py
+++ b/tests/scaffold_tests.py
@@ -7,10 +7,9 @@ target_dir = os.path.normpath(os.path.join(os.getcwd(),"testcruft"))
 
 def setup():
     os.mkdir(target_dir) #Create a temporary directory that we will delete later upon test completion
-    print("root test directory: {dir}".format(dir=target_dir))
-
+    print(f"root test directory: {target_dir}")
 def teardown():
-    print("attempting to tear down {dir}".format(dir=target_dir))
+    print(f"attempting to tear down {target_dir}")
     shutil.rmtree(target_dir) #Recursively deletes the directory and all of its contents
 
 def test_create_folder_path():
@@ -65,7 +64,7 @@ def test_create_all_files():
     
     assert_file_exists(project_root, "tests", "__init__.py")
     assert_file_exists(project_root, project_name, "__init__.py")
-    assert_file_exists(project_root, "tests", "{project_name}_tests.py".format(project_name=project_name))
+    assert_file_exists(project_root, "tests", f"{project_name}_tests.py")
     assert_file_exists(project_root, None, "setup.py")
 
 def assert_folder_exists(target_dir, sub_dir):


### PR DESCRIPTION
In Python 3.6, patch PEP 498, you now use `f"string {data}"` to format data.